### PR TITLE
templates/bird.conf.j2: Support more types, such as integers

### DIFF
--- a/templates/bird.conf.j2
+++ b/templates/bird.conf.j2
@@ -1,18 +1,20 @@
 {% macro print_config(config) %}
-{% if config is string %}
-{{ config }}
-{%- elif config is mapping %}
+{% if config is mapping %}
 {% for key, value in config.items() %}
+
 {{ key }} {
-    {{ print_config(value) | indent }}}
+    {{- print_config(value) | indent }}
+}
 {%- endfor %}
-{% else %}
+{% elif config is iterable and config is not string %}
 {% for element in config %}
 {{ print_config(element) }};
-{% endfor %}
-{% endif %}
+{%- endfor %}
+{%- else %}
+
+{{ config }}
+{%- endif %}
 {% endmacro -%}
 
 # {{ ansible_managed }}
-
 {{ print_config(bird_fact_config) }}


### PR DESCRIPTION
Previously, only strings, mappings (dicts) and other types were iterated over,
so they were quietly required to be iterable (such as lists). By explicitly
checking for iterables that are not strings, strings and a more broad range
of types now become the default case. Therefore, integers are now supported.